### PR TITLE
Use **type** instead of **account_type** while retrieving an user profile

### DIFF
--- a/src/main/scala/dispatch/github/GhUser.scala
+++ b/src/main/scala/dispatch/github/GhUser.scala
@@ -11,17 +11,23 @@ case class GhAuthorSummary(name:String, date:Date, email:String)
 
 case class GhAuthor(avatar_url: String, url: String, login: String, gravatar_id: String, id: Int)
 
-case class GhUser(id: Int, login: String, name: String, email: String, avatar_url: String, account_type: String)
+case class GhUser(id: Int, login: String, name: String, email: String, avatar_url: String, `type`: String)
 
 case class GhOwner(id:Int, login: String)
 
 
 object GhUser {
 	implicit val formats = DefaultFormats
-   
+
 	def get_authenticated_user(access_token: String) = {
 		val svc = GitHub.api_host / "user"
 		val userJson = Http(svc.secure <<? Map("access_token" -> access_token) OK as.lift.Json)
       for (js <- userJson) yield js.extract[GhUser]
 	}
+
+    def get_user(username: String) = {
+        val svc = GitHub.api_host / "users" / username
+        val userJson = Http(svc.secure OK as.lift.Json)
+      for (js <- userJson) yield js.extract[GhUser]
+    }
 }

--- a/src/test/scala/GhUserSpec.scala
+++ b/src/test/scala/GhUserSpec.scala
@@ -1,0 +1,23 @@
+package dispatch.github.specs
+
+import org.specs2.mutable._
+import dispatch._
+import dispatch.github._
+
+class GhUserSpec extends Specification {
+    "When retrieving anonymous github user profile" should {
+        "return something when the user is valid" in {
+            val userRes = GhUser.get_user("juandebravo")
+            val user = userRes()
+            (user must not beNull)
+            user.id must beEqualTo(367029)
+            user.`type` must beEqualTo("User")
+        }
+
+        "return None when the user is invalid" in {
+            val userRes = GhUser.get_user("juandebravoInvalidName")
+            val user = userRes.completeOption
+            user should be(None)
+        }
+    }
+}


### PR DESCRIPTION
GhUser is defining **account_type** as attribute, but **account_type** cannot be unserialized directly as the JSON field retrieved from github is **type**.

We could either define a post processor or use back ticks to use type as valid attribute (type is a reserved word). The former has been chosen

Also, a method to retrieve an user profile without access token has been added
